### PR TITLE
fix: enhance TruffleHog scan logic by comparing BASE and HEAD commits

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -90,12 +90,27 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set BASE and HEAD commits
+        id: commits
+        run: |
+          BASE="${{ github.event.before || github.event.pull_request.base.sha || github.event.repository.default_branch }}"
+          HEAD="${{ github.sha }}"
+          echo "base_commit=$BASE" >> $GITHUB_OUTPUT
+          echo "head_commit=$HEAD" >> $GITHUB_OUTPUT
+
+      - name: Check if BASE and HEAD are the same
+        run: |
+          if [ "${{ steps.commits.outputs.base_commit }}" = "${{ steps.commits.outputs.head_commit }}" ]; then
+            echo "BASE and HEAD commits are the same. Skipping TruffleHog scan."
+            exit 0
+          fi
+
       - name: TruffleHog OSS
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ steps.commits.outputs.base_commit }}
+          head: ${{ steps.commits.outputs.head_commit }}
           extra_args: --debug --only-verified
 
   dependency-review:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized secret scanning in CI by dynamically determining the commit range, reducing unnecessary scans.
  * Added a safeguard to skip scanning when the base and head commits are identical, speeding up runs.
  * Updated the scanning step to use computed commit references for more accurate diffs.
  * License and dependency checks remain functionally unchanged (minor formatting only).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->